### PR TITLE
Added missing Source-Url parameter and enabled scaling

### DIFF
--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -89,3 +89,8 @@ Endpoints:
     Private-Port-Name: EXTRA_PORT
     Private-Port:      15000
     Public-Port-Name:  EXTRA_PROXY_PORT
+    Mappings:
+      - Frontend:      ""
+        Backend:       ""
+        Options:       { websocket: true }
+

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -7,6 +7,7 @@ License: "ASL 2.0"
 License-Url: http://www.apache.org/licenses/LICENSE-2.0.txt
 Cartridge-Version: 0.0.1
 Cartridge-Vendor: sosiouxme
+Source-Url: https://github.com/sosiouxme/diy-extra-port-cartridge.git
 Vendor: sosiouxme
 Categories:
   - web_framework

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -89,8 +89,3 @@ Endpoints:
     Private-Port-Name: EXTRA_PORT
     Private-Port:      15000
     Public-Port-Name:  EXTRA_PROXY_PORT
-    Mappings:
-      - Frontend:      ""
-        Backend:       ""
-        Options:       { websocket: true }
-

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -69,7 +69,7 @@ Subscribes:
     Required: false
 Scaling:
   Min: 1
-  Max: 1
+  Max: -1
 Group-Overrides:
   - components:
     - web-proxy


### PR DESCRIPTION
Hi! 
Thanks for your cartridge, it will help me a lot!

Unfortunately, when I have tried to create a new app using your cartridge, I got this error:

_Creating application 'zerg' ... The provided downloadable cartridge 'https://raw.githubusercontent.com/sosiouxme/diy-extra-port-cartridge/master/metadata/manifest.yml' cannot be loaded: Source-Url is required in manifest to obtain cartridge via URL_

So I had to clone the repo and add the missing parameter. I have successfully create an app with my repo so I can confirm that it works.

Also the cartridge development documentation says that external ports are only created the application is scalable:

_(Optional) Publicly proxied ports which expose gear-local ports for use by the application’s users or intra-gear. These endpoint ports are only created when the application is scalable._
https://docs.openshift.org/origin-m4/oo_cartridge_developers_guide.html

Thank you for your time!
